### PR TITLE
Corrected inital value for transaction key generator in CoreWorkload cla...

### DIFF
--- a/perf-tool-core/src/main/java/com/linkedin/multitenant/workload/CoreWorkload.java
+++ b/perf-tool-core/src/main/java/com/linkedin/multitenant/workload/CoreWorkload.java
@@ -95,7 +95,7 @@ public class CoreWorkload implements Workload
       _LOG.debug("Number of rows for job " + jobName + " is " + rowCount);
       _rowsResponsible = rowCount / numberOfWorkers;
       _LOG.debug("Thread " + _id + " for job " + jobName + " is responsible for " + _rowsResponsible + " rows");
-      _transactionInsertKeyGen = new CounterGenerator(rowCount);
+      _transactionInsertKeyGen = new CounterGenerator(_rowsResponsible);
     }
     else
     {


### PR DESCRIPTION
I've corrected the initial value for transactionInsertKeyGen in CoreWorkload class, which is responsible for randomly creating a key for the next query.
